### PR TITLE
Use theforeman-rubocop gem

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -14,3 +14,5 @@ jobs:
   rubocop:
     name: Rubocop
     uses: theforeman/actions/.github/workflows/rubocop.yml@v0
+    with:
+      command: bundle exec rubocop --parallel --format github

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,15 +1,6 @@
-require:
-  - rubocop-performance
+inherit_gem:
+  theforeman-rubocop:
+    - default.yml
 
-Style/Documentation:
-  Enabled: false
-Lint/RaiseException:
-  Enabled: true
-Lint/StructNewOverride:
-  Enabled: true
-Style/HashEachMethods:
-  Enabled: true
-Style/HashTransformKeys:
-  Enabled: true
-Style/HashTransformValues:
-  Enabled: true
+AllCops:
+  TargetRubyVersion: 2.7

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,4 @@ gemspec
 gem 'gettext', '>= 3.1.3', '< 4.0.0'
 gem 'rake', '~> 13.0'
 
-group :test do
-  gem 'rubocop', '~> 1.57.0'
-  gem 'rubocop-performance', '~> 1.5.2'
-end
+gem 'theforeman-rubocop', '~> 0.1.0'

--- a/hammer_cli_foreman_leapp.gemspec
+++ b/hammer_cli_foreman_leapp.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.name          = 'hammer_cli_foreman_leapp'
   spec.version       = HammerCLIForemanLeapp.version.dup
   spec.license       = 'GPL-3.0'
-  spec.date          = Date.today.to_s
+  spec.date          = Time.now.utc.to_date.to_s
   spec.authors       = ['Foreman Leapp team']
   spec.email         = ['foreman-dev@googlegroups.com']
   spec.homepage      = 'https://github.com/stejskalleos/hammer-cli-foreman-leapp'


### PR DESCRIPTION
Choose to inherit default.yml style because this rules have target ruby and rails version included. Also dropped some cops from here because that was either included in the inherit file or was not needed anymore and fixed some fo the cops like Rails/Date and Gemspec/RequiredRubyVersion.

default.yml: https://github.com/theforeman/theforeman-rubocop/?tab=readme-ov-file#basic-style---default-performance-and-rails-cops

This is part of Rubocop standerdization, link for the reference: https://community.theforeman.org/t/standardizing-rubocop-with-theforeman-rubocop/37239