### PR TITLE
Relax hammer_cli_foreman dependency to allow 5.x

### DIFF
--- a/hammer_cli_foreman_leapp.gemspec
+++ b/hammer_cli_foreman_leapp.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.test_files    = Dir['{test}/**/*']
 
-  spec.add_dependency 'hammer_cli_foreman', '~> 5.0'
+  spec.add_dependency 'hammer_cli_foreman', '>= 3.10', '< 6.0'
   spec.required_ruby_version = '>= 2.7', '< 4'
 end

--- a/hammer_cli_foreman_leapp.gemspec
+++ b/hammer_cli_foreman_leapp.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.test_files    = Dir['{test}/**/*']
 
-  spec.add_dependency 'hammer_cli_foreman', '~> 3.10'
+  spec.add_dependency 'hammer_cli_foreman', '~> 5.0'
   spec.required_ruby_version = '>= 2.7', '< 4'
 end


### PR DESCRIPTION
## Summary
- Relax the hammer_cli_foreman version constraint from ~> 3.10 to ~> 5.0 to allow compatibility with the upcoming 5.0 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)